### PR TITLE
Add rke_node_parameter data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,36 @@ resource rke_cluster "cluster" {
 * default k8s version: `v1.10.1-rancher1`
 * default network plugin: `canal`
 
+#### Dynamic multiple nodes example
+
+```hcl
+variable "node_addrs" {
+  type    = "list"
+  default = ["192.2.0.1", "192.2.0.2"]
+}
+
+data rke_node_parameter "nodes" {
+  count   = "${length(var.node_addrs)}"
+
+  address = "${var.node_addrs[count.index]}"
+  user    = "ubuntu"
+  role    = ["controlplane", "worker", "etcd"]
+  ssh_key = "${file("~/.ssh/id_rsa")}"
+}
+
+resource rke_cluster "cluster" {
+  nodes_conf = ["${data.rke_node_parameter.nodes.*.json}"]
+}
+
+###############################################################################
+# If you need kubeconfig.yml for using kubectl, please uncomment follows.
+###############################################################################
+//resource "local_file" "kube_cluster_yaml" {
+//  filename = "${path.root}/kube_config_cluster.yml"
+//  content = "${rke_cluster.cluster.kube_config_yaml}"
+//}
+```
+
 #### With cloud provider
 
 - [AWS(EC2)](examples/aws_ec2)

--- a/examples/multiple_nodes/example.tf
+++ b/examples/multiple_nodes/example.tf
@@ -1,0 +1,26 @@
+variable "node_addrs" {
+  type    = "list"
+  default = ["192.2.0.1", "192.2.0.2"]
+}
+
+data rke_node_parameter "nodes" {
+  count   = "${length(var.node_addrs)}"
+
+  address = "${var.node_addrs[count.index]}"
+  user    = "ubuntu"
+  role    = ["controlplane", "worker", "etcd"]
+  ssh_key = "${file("~/.ssh/id_rsa")}"
+}
+
+resource rke_cluster "cluster" {
+  nodes_conf = ["${data.rke_node_parameter.nodes.*.json}"]
+}
+
+###############################################################################
+# If you need kubeconfig.yml for using kubectl, please uncomment follows.
+###############################################################################
+//resource "local_file" "kube_cluster_yaml" {
+//  filename = "${path.root}/kube_config_cluster.yml"
+//  content = "${rke_cluster.cluster.kube_config_yaml}"
+//}
+

--- a/rke/data_source_rke_node_parameter.go
+++ b/rke/data_source_rke_node_parameter.go
@@ -1,0 +1,56 @@
+package rke
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"gopkg.in/yaml.v2"
+)
+
+func dataSourceRKENodeParameter() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceRKENodeParameterRead,
+		Schema: nodeDataSourceSchema(),
+	}
+}
+
+func resourceRKENodeParameterRead(d *schema.ResourceData, _ interface{}) error {
+
+	nodeValues := map[string]interface{}{
+		"node_name":         d.Get("node_name"),
+		"address":           d.Get("address"),
+		"port":              d.Get("port"),
+		"internal_address":  d.Get("internal_address"),
+		"role":              d.Get("role"),
+		"roles":             d.Get("roles"),
+		"hostname_override": d.Get("hostname_override"),
+		"user":              d.Get("user"),
+		"docker_socket":     d.Get("docker_socket"),
+		"ssh_agent_auth":    d.Get("ssh_agent_auth"),
+		"ssh_key":           d.Get("ssh_key"),
+		"ssh_key_path":      d.Get("ssh_key_path"),
+		"labels":            d.Get("labels"),
+	}
+
+	node, err := parseResourceRKEConfigNode(nodeValues)
+	if err != nil {
+		return err
+	}
+
+	// to YAML
+	strYAML, err := yaml.Marshal(&node)
+	if err != nil {
+		return err
+	}
+	d.Set("yaml", string(strYAML))
+
+	// to JSON
+	strJSON, err := json.Marshal(&node)
+	if err != nil {
+		return err
+	}
+	d.Set("json", string(strJSON))
+
+	d.SetId(d.Get("address").(string))
+	return nil
+}

--- a/rke/data_source_rke_node_parameter_test.go
+++ b/rke/data_source_rke_node_parameter_test.go
@@ -1,0 +1,37 @@
+package rke
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccRKENodesConfDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckRKENodesConfDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.rke_node_parameter.foobar", "address", "192.2.0.1"),
+					resource.TestMatchResourceAttr("data.rke_node_parameter.foobar",
+						"json",
+						regexp.MustCompile(".+")), // should be not empty
+					resource.TestMatchResourceAttr("data.rke_node_parameter.foobar",
+						"yaml",
+						regexp.MustCompile(".+")), // should be not empty
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckRKENodesConfDataSourceConfig = `
+data rke_node_parameter "foobar" {
+  address = "192.2.0.1"
+  user    = "root"
+  role    = ["controlplane", "worker", "etcd"]
+}
+`

--- a/rke/node_schema.go
+++ b/rke/node_schema.go
@@ -1,0 +1,108 @@
+package rke
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func nodeSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"node_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Name of the host provisioned via docker machine",
+		},
+		"address": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "IP or FQDN that is fully resolvable and used for SSH communication",
+		},
+		"port": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validateIntegerInRange(1, 65535),
+			Description:  "Port used for SSH communication",
+		},
+		"internal_address": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Internal address that will be used for components communication",
+		},
+		"role": {
+			Type:     schema.TypeList,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Optional: true,
+			// cannot use ConflictsWith in this context. see https://github.com/terraform-providers/terraform-provider-google/pull/1062
+			// ConflictsWith: []string{"roles"},
+			Description: "Node role in kubernetes cluster [controlplane/worker/etcd])",
+		},
+		"roles": {
+			Type:     schema.TypeString,
+			Optional: true,
+			// cannot use ConflictsWith in this context. see https://github.com/terraform-providers/terraform-provider-google/pull/1062
+			// ConflictsWith: []string{"role"},
+			Deprecated:  "roles is a workaround when a role can not be specified in list",
+			Description: "Node role in kubernetes cluster [controlplane/worker/etcd], specified by a comma-separated string",
+		},
+		"hostname_override": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "HostnameOverride",
+		},
+		"user": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "SSH user that will be used by RKE",
+		},
+		"docker_socket": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Docker socket on the node that will be used in tunneling",
+		},
+		"ssh_agent_auth": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "SSH Agent Auth enable",
+		},
+		"ssh_key": {
+			Type:        schema.TypeString,
+			Sensitive:   true,
+			Optional:    true,
+			Computed:    true,
+			Description: "SSH Private Key",
+		},
+		"ssh_key_path": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "SSH Private Key",
+		},
+		"labels": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Node Labels",
+		},
+	}
+}
+
+func nodeDataSourceSchema() map[string]*schema.Schema {
+	nodeSchema := nodeSchema()
+
+	nodeSchema["yaml"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "RKE Node YAML",
+	}
+	nodeSchema["json"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "RKE Node JSON",
+	}
+
+	return nodeSchema
+}

--- a/rke/provider.go
+++ b/rke/provider.go
@@ -22,6 +22,9 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"rke_cluster": resourceRKECluster(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"rke_node_parameter": dataSourceRKENodeParameter(),
+		},
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/rke/resource_rke_cluster.go
+++ b/rke/resource_rke_cluster.go
@@ -34,100 +34,24 @@ func resourceRKECluster() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"nodes_conf": {
+				Type:          schema.TypeList,
+				MinItems:      1,
+				Optional:      true,
+				Description:   "Kubernetes nodes(YAML or JSON)",
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"nodes"},
+			},
 			"nodes": {
 				Type:        schema.TypeList,
-				Required:    true,
 				MinItems:    1,
+				Optional:    true,
 				Description: "Kubernetes nodes",
 				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"node_name": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-							Description: "Name of the host provisioned via docker machine",
-						},
-						"address": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "IP or FQDN that is fully resolvable and used for SSH communication",
-						},
-						"port": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validateIntegerInRange(1, 65535),
-							Description:  "Port used for SSH communication",
-						},
-						"internal_address": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-							Description: "Internal address that will be used for components communication",
-						},
-						"role": {
-							Type:          schema.TypeList,
-							Elem:          &schema.Schema{Type: schema.TypeString},
-							Optional:      true,
-							// cannot use ConflictsWith in this context. see https://github.com/terraform-providers/terraform-provider-google/pull/1062
-							// ConflictsWith: []string{"roles"},
-							Description:   "Node role in kubernetes cluster [controlplane/worker/etcd])",
-						},
-						"roles": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							// cannot use ConflictsWith in this context. see https://github.com/terraform-providers/terraform-provider-google/pull/1062
-							// ConflictsWith: []string{"role"},
-							Deprecated:    "roles is a workaround when a role can not be specified in list",
-							Description:   "Node role in kubernetes cluster [controlplane/worker/etcd], specified by a comma-separated string",
-						},
-						"hostname_override": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-							Description: "HostnameOverride",
-						},
-						"user": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-							Description: "SSH user that will be used by RKE",
-						},
-						"docker_socket": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-							Description: "Docker socket on the node that will be used in tunneling",
-						},
-						"ssh_agent_auth": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Computed:    true,
-							Description: "SSH Agent Auth enable",
-						},
-						"ssh_key": {
-							Type:        schema.TypeString,
-							Sensitive:   true,
-							Optional:    true,
-							Computed:    true,
-							Description: "SSH Private Key",
-						},
-						"ssh_key_path": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-							Description: "SSH Private Key",
-						},
-						"labels": {
-							Type:        schema.TypeMap,
-							Optional:    true,
-							Computed:    true,
-							Description: "Node Labels",
-						},
-					},
+					Schema: nodeSchema(),
 				},
+				ConflictsWith: []string{"nodes_conf"},
 			},
-
 			"services_etcd": {
 				Type:     schema.TypeList,
 				MaxItems: 1,


### PR DESCRIPTION
To fix #5 

Add `rke_node_parameter` data source for dynamic and multiple nodes

#### example

```
variable "node_addrs" {
  type    = "list"
  default = ["192.2.0.1", "192.2.0.2"]
}

# dynamic nodes configuration
data rke_node_parameter "nodes" {
  count   = "${length(var.node_addrs)}"

  address = "${var.node_addrs[count.index]}"
  user    = "ubuntu"
  role    = ["controlplane", "worker", "etcd"]
  ssh_key = "${file("~/.ssh/id_rsa")}"
}

resource rke_cluster "cluster" {
  nodes_conf = ["${data.rke_node_parameter.nodes.*.json}"]
}
```

`rke_cluster.nodes_conf`  is `schema.TypeList`.
It allows `JSON` or `YAML` format strings.

`rke_node_parameter` data source has same attrs to `rke_cluster.nodes`.
Also it has following two computed attrs:

- `json` 
- `yaml`



