### PR TITLE
Supports addons upgrade

### DIFF
--- a/rke/resource_rke_cluster.go
+++ b/rke/resource_rke_cluster.go
@@ -430,7 +430,6 @@ func resourceRKECluster() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
 				Description: "YAML manifest for user provided addons to be deployed on the cluster",
 			},
 			"addons_include": {
@@ -438,7 +437,6 @@ func resourceRKECluster() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
 				Description: "List of urls or paths for addons",
 			},
 			"addon_job_timeout": {


### PR DESCRIPTION
To fix #14

Currently, both `rke_cluster.addons` and` rke_cluster.addons_include` are set to `ForceNew: true`.

This is because RKE didn't support addons upgrades before.
However it is now supported.

> refs: https://github.com/rancher/rke/pull/680

So, this PR change `rke_cluster` schema to support addons upgrades.