### PR TITLE
Make shell scripts more portable

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/build_on_docker.sh
+++ b/scripts/build_on_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Some non-Linux systems don't ship with the `bash` command in the /bin
directory -- in fact, some don't ship with bash at all.

Using `/usr/bin/env` to find the bash executable ensures that if there
is a `bash` executable on the PATH it will be used.