### PR TITLE
Upgrade to RKE v0.1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Terraform RKE providers can easily deploy Kubernetes clusters with [Rancher Kube
 #### Compatible Versions
 
 - Terraform: v0.11+
-- RKE: v0.1.15
+- RKE: v0.1.16
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.1.1 // indirect
-	github.com/rancher/rke v0.1.15
+	github.com/rancher/rke v0.1.16
 	github.com/rancher/types v0.0.0-20190103014026-1e7d94553cfa
 	github.com/sirupsen/logrus v1.0.6
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect


### PR DESCRIPTION
RKE v0.1.16 have released.

https://github.com/rancher/rke/releases/tag/v0.1.16

After RKE v0.1.16, docker 18.06 and 18.09 are available.
refs: https://github.com/rancher/rke/compare/v0.1.15...v0.1.16