### PR TITLE
Fix where to create temporary files

### DIFF
--- a/rke/resource_rke_cluster.go
+++ b/rke/resource_rke_cluster.go
@@ -1481,7 +1481,7 @@ func clusterUp(d *schema.ResourceData) error {
 
 	apiURL, caCrt, clientCert, clientKey, clusterUpErr := realClusterUp(context.Background(),
 		rkeConfig, nil, nil, nil,
-		clusterFilePath, tempDir, false, disablePortCheck)
+		clusterFilePath, "", false, disablePortCheck)
 	if clusterUpErr != nil {
 		return clusterUpErr
 	}
@@ -1511,7 +1511,7 @@ func clusterRemove(d *schema.ResourceData) error {
 	}
 
 	return realClusterRemove(context.Background(),
-		rkeConfig, nil, nil, clusterFilePath, tempDir)
+		rkeConfig, nil, nil, clusterFilePath, "")
 }
 
 func realClusterUp( // nolint: gocyclo
@@ -1723,7 +1723,7 @@ func readClusterState(d *schema.ResourceData) (*cluster.Cluster, error) {
 
 	ctx := context.Background()
 	kubeCluster, err := cluster.ParseCluster(ctx, rkeConfig, clusterFilePath,
-		tempDir, nil, nil, nil)
+		"", nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1737,7 +1737,8 @@ func readClusterState(d *schema.ResourceData) (*cluster.Cluster, error) {
 }
 
 func readKubeConfig(dir string) (string, error) {
-	localKubeConfigPath := pki.GetLocalKubeConfig(pki.ClusterConfig, dir)
+	configPath := filepath.Join(dir, pki.ClusterConfig)
+	localKubeConfigPath := pki.GetLocalKubeConfig(configPath, "")
 	if _, err := os.Stat(localKubeConfigPath); err == nil {
 		var data []byte
 		if data, err = ioutil.ReadFile(localKubeConfigPath); err != nil {
@@ -1752,7 +1753,8 @@ func writeKubeConfigFile(dir string, d *schema.ResourceData) error {
 	if rawKubeConfig, ok := d.GetOk("kube_config_yaml"); ok {
 		strConf := rawKubeConfig.(string)
 		if strConf != "" {
-			localKubeConfigPath := pki.GetLocalKubeConfig(pki.ClusterConfig, dir)
+			configPath := filepath.Join(dir, pki.ClusterConfig)
+			localKubeConfigPath := pki.GetLocalKubeConfig(configPath, "")
 			if err := ioutil.WriteFile(localKubeConfigPath, []byte(strConf), 0640); err != nil {
 				return err
 			}


### PR DESCRIPTION
(from [@mkozjak's comment](https://github.com/yamamoto-febc/terraform-provider-rke/pull/53#commitcomment-32344550), thank you @mkozjak!)

This PR fixes to where to create temporary files.

### Motivation/Background

The expected behavior of creating temporary files is as follows:

* RKE provider make temporary directory in current directory with random name.
* While running RKE provider, `cluster.yml` and `kube_config_cluster.yml` is generated into the temporary directory.
* After running RKE provider, the temporary directory is cleaned up.

However, current provider doesn't work well. 

This unexpected behavior is based on to bad calling to following RKE's function:

https://github.com/rancher/rke/blob/v0.1.15/pki/util.go#L278-L286

Function `pki.GetLocalKubeConfig` has two arguments.
The function changes the behavior depending on whether there is a slash at the end of the second argument.

If args are (`cluster.yml`, `/foo/bar/`),  the function returns `/foo/bar/kube_config_cluster.yml`.
If args are (`cluster.yml`, `/foo/bar`),  the function returns `/foo/kube_config_cluster.yml`.

This is very confusing.

So I decided don't use second argument, always specify `""`.

### Acceptance test results:
<details>

```sh
$ make testacc
TF_ACC=1 go test ./... -v  -timeout 240m ; \

?   	github.com/yamamoto-febc/terraform-provider-rke	[no test files]
=== RUN   TestAccRKENodesConfDataSource
--- PASS: TestAccRKENodesConfDataSource (0.02s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccResourceRKECluster
--- PASS: TestAccResourceRKECluster (205.13s)
=== RUN   TestAccResourceRKECluster_NodeCountUpAndDown
--- PASS: TestAccResourceRKECluster_NodeCountUpAndDown (345.66s)
=== RUN   TestAccResourceRKEClusterWithNodeParameter
--- PASS: TestAccResourceRKEClusterWithNodeParameter (150.11s)
=== RUN   TestParseResourceRKEConfigNode
=== RUN   TestParseResourceRKEConfigNode/minimum_fields
=== RUN   TestParseResourceRKEConfigNode/with_both_role_and_roles
=== RUN   TestParseResourceRKEConfigNode/without_both_role_and_roles
=== RUN   TestParseResourceRKEConfigNode/invalid_role
=== RUN   TestParseResourceRKEConfigNode/invalid_roles
=== RUN   TestParseResourceRKEConfigNode/use_roles_attr
=== RUN   TestParseResourceRKEConfigNode/all_fields
--- PASS: TestParseResourceRKEConfigNode (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/minimum_fields (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/with_both_role_and_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/without_both_role_and_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/invalid_role (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/invalid_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/use_roles_attr (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/all_fields (0.00s)
=== RUN   TestParseResourceRKEConfigNodesConf
=== RUN   TestParseResourceRKEConfigNodesConf/JSON
=== RUN   TestParseResourceRKEConfigNodesConf/YAML
=== RUN   TestParseResourceRKEConfigNodesConf/both_JSON_and_YAML
--- PASS: TestParseResourceRKEConfigNodesConf (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/JSON (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/YAML (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/both_JSON_and_YAML (0.00s)
=== RUN   TestParseResourceETCDService
=== RUN   TestParseResourceETCDService/all_fields
--- PASS: TestParseResourceETCDService (0.00s)
    --- PASS: TestParseResourceETCDService/all_fields (0.00s)
=== RUN   TestParseResourceKubeAPIService
=== RUN   TestParseResourceKubeAPIService/all_fields
--- PASS: TestParseResourceKubeAPIService (0.00s)
    --- PASS: TestParseResourceKubeAPIService/all_fields (0.00s)
=== RUN   TestParseResourceKubeControllerService
=== RUN   TestParseResourceKubeControllerService/all_fields
--- PASS: TestParseResourceKubeControllerService (0.00s)
    --- PASS: TestParseResourceKubeControllerService/all_fields (0.00s)
=== RUN   TestParseResourceSchedulerService
=== RUN   TestParseResourceSchedulerService/all_fields
--- PASS: TestParseResourceSchedulerService (0.00s)
    --- PASS: TestParseResourceSchedulerService/all_fields (0.00s)
=== RUN   TestParseResourceKubeletService
=== RUN   TestParseResourceKubeletService/all_fields
--- PASS: TestParseResourceKubeletService (0.00s)
    --- PASS: TestParseResourceKubeletService/all_fields (0.00s)
=== RUN   TestParseResourceKubeproxyService
=== RUN   TestParseResourceKubeproxyService/all_fields
--- PASS: TestParseResourceKubeproxyService (0.00s)
    --- PASS: TestParseResourceKubeproxyService/all_fields (0.00s)
=== RUN   TestParseResourceNetwork
=== RUN   TestParseResourceNetwork/all_fields
--- PASS: TestParseResourceNetwork (0.00s)
    --- PASS: TestParseResourceNetwork/all_fields (0.00s)
=== RUN   TestParseResourceAuthentication
=== RUN   TestParseResourceAuthentication/all_fields
--- PASS: TestParseResourceAuthentication (0.00s)
    --- PASS: TestParseResourceAuthentication/all_fields (0.00s)
=== RUN   TestParseResourceAddons
--- PASS: TestParseResourceAddons (0.00s)
=== RUN   TestParseResourceAddonsInclude
--- PASS: TestParseResourceAddonsInclude (0.00s)
=== RUN   TestParseResourceAddonJobTimeout
--- PASS: TestParseResourceAddonJobTimeout (0.00s)
=== RUN   TestParseResourceSSHKeyPath
--- PASS: TestParseResourceSSHKeyPath (0.00s)
=== RUN   TestParseResourceSSHAgentAuth
--- PASS: TestParseResourceSSHAgentAuth (0.00s)
=== RUN   TestParseResourceBastionHost
=== RUN   TestParseResourceBastionHost/all_fields
--- PASS: TestParseResourceBastionHost (0.00s)
    --- PASS: TestParseResourceBastionHost/all_fields (0.00s)
=== RUN   TestParseResourceMonitoring
=== RUN   TestParseResourceMonitoring/all_fields
--- PASS: TestParseResourceMonitoring (0.00s)
    --- PASS: TestParseResourceMonitoring/all_fields (0.00s)
=== RUN   TestParseResourceAuthorization
=== RUN   TestParseResourceAuthorization/all_fields
--- PASS: TestParseResourceAuthorization (0.00s)
    --- PASS: TestParseResourceAuthorization/all_fields (0.00s)
=== RUN   TestParseResourceIgnoreDockerVersion
--- PASS: TestParseResourceIgnoreDockerVersion (0.00s)
=== RUN   TestParseResourceKubernetesVersion
--- PASS: TestParseResourceKubernetesVersion (0.00s)
=== RUN   TestParseResourcePrivateRegistries
=== RUN   TestParseResourcePrivateRegistries/all_fields
--- PASS: TestParseResourcePrivateRegistries (0.00s)
    --- PASS: TestParseResourcePrivateRegistries/all_fields (0.00s)
=== RUN   TestParseResourceIngress
=== RUN   TestParseResourceIngress/all_fields
--- PASS: TestParseResourceIngress (0.00s)
    --- PASS: TestParseResourceIngress/all_fields (0.00s)
=== RUN   TestParseResourceClusterName
--- PASS: TestParseResourceClusterName (0.00s)
=== RUN   TestParseResourceCloudProvider
=== RUN   TestParseResourceCloudProvider/all_fields
--- PASS: TestParseResourceCloudProvider (0.00s)
    --- PASS: TestParseResourceCloudProvider/all_fields (0.00s)
=== RUN   TestParseResourcePrefixPath
--- PASS: TestParseResourcePrefixPath (0.00s)
=== RUN   TestClusterToState
=== RUN   TestClusterToState/all_fields
--- PASS: TestClusterToState (0.00s)
    --- PASS: TestClusterToState/all_fields (0.00s)
PASS
ok  	github.com/yamamoto-febc/terraform-provider-rke/rke	701.005s
?   	github.com/yamamoto-febc/terraform-provider-rke/tools/plugin-protocol-version	[no test files]
?   	github.com/yamamoto-febc/terraform-provider-rke/tools/terraform-version	[no test files]
```

</details>