### PR TITLE
RKE v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Terraform RKE providers can easily deploy Kubernetes clusters with [Rancher Kube
 #### Compatible Versions
 
 - Terraform: v0.11+(includes v0.12)
-- RKE: v0.2.0-rc7
+- RKE: v0.2.1
 
 **Current master is focusing on RKE v0.2.x. If you use RKE v0.1.x, please see [rke/v0.1.x](https://github.com/yamamoto-febc/terraform-provider-rke/tree/rke/v0.1.x) branch.**
 
@@ -64,7 +64,7 @@ resource rke_cluster "cluster" {
 //}
 ```
 
-* default k8s version: `v1.13.1-rancher1-1`
+* default k8s version: `v1.13.5-rancher1-2`
 * default network plugin: `canal`
 
 #### Dynamic multiple nodes example

--- a/examples/full/example.tf
+++ b/examples/full/example.tf
@@ -102,7 +102,9 @@ EOL
   #
   # In case the kubernetes_version and kubernetes image in system_images are defined,
   # the system_images configuration will take precedence over kubernetes_version.
-  kubernetes_version = "v1.13.1-rancher1-1"
+  #
+  # Allowed values: [v1.13.5-rancher1-2(default), v1.12.7-rancher1-2, v1.11.9-rancher1-1]
+  kubernetes_version = "v1.13.5-rancher1-2"
 
   ################################################
   # System Images

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,8 @@ require (
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/prometheus/client_golang v0.9.2 // indirect
 	github.com/rancher/norman v0.0.0-20181220035647-0557aa4ff31a // indirect
-	github.com/rancher/rke v0.2.0-rc7
-	github.com/rancher/types v0.0.0-20190222190138-5b7ed44f9287
+	github.com/rancher/rke v0.2.1
+	github.com/rancher/types v0.0.0-20190326222017-58b8fb504c8a
 	github.com/sirupsen/logrus v1.1.1
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c // indirect

--- a/rke/structure.go
+++ b/rke/structure.go
@@ -275,7 +275,7 @@ func setDNSFromResource(rkeConfig *v3.RancherKubernetesEngineConfig, d resourceD
 		return err
 	}
 	if dns != nil {
-		rkeConfig.DNS = *dns
+		rkeConfig.DNS = dns
 	}
 	return nil
 }

--- a/rke/structure_test.go
+++ b/rke/structure_test.go
@@ -1630,7 +1630,7 @@ func TestClusterToState(t *testing.T) {
 						CACertificates: true,
 						Services:       []string{"etcd", "kubelet"},
 					},
-					DNS: v3.DNSConfig{
+					DNS: &v3.DNSConfig{
 						Provider:            "core-dns",
 						UpstreamNameservers: []string{"8.8.8.8", "8.8.4.4"},
 						ReverseCIDRs:        []string{"1.0.2.192.in-addr.arpa", "2.0.2.192.in-addr.arpa"},


### PR DESCRIPTION
Acceptance test results:

<details>

```console
$ make testacc
TF_ACC=1 go test ./... -v  -timeout 240m ; \

?   	github.com/yamamoto-febc/terraform-provider-rke	[no test files]
=== RUN   TestAccRKENodesConfDataSource
--- PASS: TestAccRKENodesConfDataSource (0.05s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccResourceRKECluster
--- PASS: TestAccResourceRKECluster (216.56s)
=== RUN   TestAccResourceRKECluster_NodeCountUpAndDown
--- PASS: TestAccResourceRKECluster_NodeCountUpAndDown (375.97s)
=== RUN   TestAccResourceRKEClusterWithNodeParameter
--- PASS: TestAccResourceRKEClusterWithNodeParameter (195.57s)
=== RUN   TestParseResourceRKEConfigNode
=== RUN   TestParseResourceRKEConfigNode/minimum_fields
=== RUN   TestParseResourceRKEConfigNode/with_both_role_and_roles
=== RUN   TestParseResourceRKEConfigNode/without_both_role_and_roles
=== RUN   TestParseResourceRKEConfigNode/invalid_role
=== RUN   TestParseResourceRKEConfigNode/invalid_roles
=== RUN   TestParseResourceRKEConfigNode/use_roles_attr
=== RUN   TestParseResourceRKEConfigNode/all_fields
--- PASS: TestParseResourceRKEConfigNode (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/minimum_fields (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/with_both_role_and_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/without_both_role_and_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/invalid_role (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/invalid_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/use_roles_attr (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/all_fields (0.00s)
=== RUN   TestParseResourceRKEConfigNodesConf
=== RUN   TestParseResourceRKEConfigNodesConf/JSON
=== RUN   TestParseResourceRKEConfigNodesConf/YAML
=== RUN   TestParseResourceRKEConfigNodesConf/both_JSON_and_YAML
--- PASS: TestParseResourceRKEConfigNodesConf (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/JSON (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/YAML (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/both_JSON_and_YAML (0.00s)
=== RUN   TestParseResourceETCDService
=== RUN   TestParseResourceETCDService/all_fields
--- PASS: TestParseResourceETCDService (0.00s)
    --- PASS: TestParseResourceETCDService/all_fields (0.00s)
=== RUN   TestParseResourceKubeAPIService
=== RUN   TestParseResourceKubeAPIService/all_fields
--- PASS: TestParseResourceKubeAPIService (0.00s)
    --- PASS: TestParseResourceKubeAPIService/all_fields (0.00s)
=== RUN   TestParseResourceKubeControllerService
=== RUN   TestParseResourceKubeControllerService/all_fields
--- PASS: TestParseResourceKubeControllerService (0.00s)
    --- PASS: TestParseResourceKubeControllerService/all_fields (0.00s)
=== RUN   TestParseResourceSchedulerService
=== RUN   TestParseResourceSchedulerService/all_fields
--- PASS: TestParseResourceSchedulerService (0.00s)
    --- PASS: TestParseResourceSchedulerService/all_fields (0.00s)
=== RUN   TestParseResourceKubeletService
=== RUN   TestParseResourceKubeletService/all_fields
--- PASS: TestParseResourceKubeletService (0.00s)
    --- PASS: TestParseResourceKubeletService/all_fields (0.00s)
=== RUN   TestParseResourceKubeproxyService
=== RUN   TestParseResourceKubeproxyService/all_fields
--- PASS: TestParseResourceKubeproxyService (0.00s)
    --- PASS: TestParseResourceKubeproxyService/all_fields (0.00s)
=== RUN   TestParseResourceNetwork
=== RUN   TestParseResourceNetwork/all_fields
--- PASS: TestParseResourceNetwork (0.00s)
    --- PASS: TestParseResourceNetwork/all_fields (0.00s)
=== RUN   TestParseResourceAuthentication
=== RUN   TestParseResourceAuthentication/all_fields
--- PASS: TestParseResourceAuthentication (0.00s)
    --- PASS: TestParseResourceAuthentication/all_fields (0.00s)
=== RUN   TestParseResourceAddons
--- PASS: TestParseResourceAddons (0.00s)
=== RUN   TestParseResourceAddonsInclude
--- PASS: TestParseResourceAddonsInclude (0.00s)
=== RUN   TestParseResourceAddonJobTimeout
--- PASS: TestParseResourceAddonJobTimeout (0.00s)
=== RUN   TestParseResourceSSHKeyPath
--- PASS: TestParseResourceSSHKeyPath (0.00s)
=== RUN   TestParseResourceSSHAgentAuth
--- PASS: TestParseResourceSSHAgentAuth (0.00s)
=== RUN   TestParseResourceBastionHost
=== RUN   TestParseResourceBastionHost/all_fields
--- PASS: TestParseResourceBastionHost (0.00s)
    --- PASS: TestParseResourceBastionHost/all_fields (0.00s)
=== RUN   TestParseResourceMonitoring
=== RUN   TestParseResourceMonitoring/all_fields
--- PASS: TestParseResourceMonitoring (0.00s)
    --- PASS: TestParseResourceMonitoring/all_fields (0.00s)
=== RUN   TestParseResourceRestore
=== RUN   TestParseResourceRestore/all_fields
--- PASS: TestParseResourceRestore (0.00s)
    --- PASS: TestParseResourceRestore/all_fields (0.00s)
=== RUN   TestParseResourceRotateCertificates
=== RUN   TestParseResourceRotateCertificates/all_fields
--- PASS: TestParseResourceRotateCertificates (0.00s)
    --- PASS: TestParseResourceRotateCertificates/all_fields (0.00s)
=== RUN   TestParseResourceDNS
=== RUN   TestParseResourceDNS/all_fields
--- PASS: TestParseResourceDNS (0.00s)
    --- PASS: TestParseResourceDNS/all_fields (0.00s)
=== RUN   TestParseResourceAuthorization
=== RUN   TestParseResourceAuthorization/all_fields
--- PASS: TestParseResourceAuthorization (0.00s)
    --- PASS: TestParseResourceAuthorization/all_fields (0.00s)
=== RUN   TestParseResourceIgnoreDockerVersion
--- PASS: TestParseResourceIgnoreDockerVersion (0.00s)
=== RUN   TestParseResourceKubernetesVersion
--- PASS: TestParseResourceKubernetesVersion (0.00s)
=== RUN   TestParseResourcePrivateRegistries
=== RUN   TestParseResourcePrivateRegistries/all_fields
--- PASS: TestParseResourcePrivateRegistries (0.00s)
    --- PASS: TestParseResourcePrivateRegistries/all_fields (0.00s)
=== RUN   TestParseResourceIngress
=== RUN   TestParseResourceIngress/all_fields
--- PASS: TestParseResourceIngress (0.00s)
    --- PASS: TestParseResourceIngress/all_fields (0.00s)
=== RUN   TestParseResourceClusterName
--- PASS: TestParseResourceClusterName (0.00s)
=== RUN   TestParseResourceCloudProvider
=== RUN   TestParseResourceCloudProvider/all_fields
--- PASS: TestParseResourceCloudProvider (0.00s)
    --- PASS: TestParseResourceCloudProvider/all_fields (0.00s)
=== RUN   TestParseResourcePrefixPath
--- PASS: TestParseResourcePrefixPath (0.00s)
=== RUN   TestClusterToState
=== RUN   TestClusterToState/all_fields
--- PASS: TestClusterToState (0.00s)
    --- PASS: TestClusterToState/all_fields (0.00s)
PASS
ok  	github.com/yamamoto-febc/terraform-provider-rke/rke	788.213s
?   	github.com/yamamoto-febc/terraform-provider-rke/tools/plugin-protocol-version	[no test files]
?   	github.com/yamamoto-febc/terraform-provider-rke/tools/terraform-version	[no test files]
```

</details>