### PR TITLE
Set rke_cluster.network.options to Computed:true

### DIFF
--- a/rke/schema.go
+++ b/rke/schema.go
@@ -539,6 +539,7 @@ func ClusterSchema() map[string]*schema.Schema {
 					"options": {
 						Type:        schema.TypeMap,
 						Optional:    true,
+						Computed:    true,
 						Description: "Plugin options to configure network properties",
 					},
 				},


### PR DESCRIPTION
(based on #74)

This PR sets `rke_cluster.network.options` to `Computed:true`

#### Acceptance test results:

<details>

```console
$ make testacc
TF_ACC=1 go test ./... -v  -timeout 240m ; \

?   	github.com/yamamoto-febc/terraform-provider-rke	[no test files]
=== RUN   TestAccRKENodesConfDataSource
--- PASS: TestAccRKENodesConfDataSource (0.02s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccResourceRKECluster
--- PASS: TestAccResourceRKECluster (208.76s)
=== RUN   TestAccResourceRKECluster_NodeCountUpAndDown
--- PASS: TestAccResourceRKECluster_NodeCountUpAndDown (352.73s)
=== RUN   TestAccResourceRKEClusterWithNodeParameter
--- PASS: TestAccResourceRKEClusterWithNodeParameter (133.62s)
=== RUN   TestParseResourceRKEConfigNode
=== RUN   TestParseResourceRKEConfigNode/minimum_fields
=== RUN   TestParseResourceRKEConfigNode/with_both_role_and_roles
=== RUN   TestParseResourceRKEConfigNode/without_both_role_and_roles
=== RUN   TestParseResourceRKEConfigNode/invalid_role
=== RUN   TestParseResourceRKEConfigNode/invalid_roles
=== RUN   TestParseResourceRKEConfigNode/use_roles_attr
=== RUN   TestParseResourceRKEConfigNode/all_fields
--- PASS: TestParseResourceRKEConfigNode (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/minimum_fields (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/with_both_role_and_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/without_both_role_and_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/invalid_role (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/invalid_roles (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/use_roles_attr (0.00s)
    --- PASS: TestParseResourceRKEConfigNode/all_fields (0.00s)
=== RUN   TestParseResourceRKEConfigNodesConf
=== RUN   TestParseResourceRKEConfigNodesConf/JSON
=== RUN   TestParseResourceRKEConfigNodesConf/YAML
=== RUN   TestParseResourceRKEConfigNodesConf/both_JSON_and_YAML
--- PASS: TestParseResourceRKEConfigNodesConf (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/JSON (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/YAML (0.00s)
    --- PASS: TestParseResourceRKEConfigNodesConf/both_JSON_and_YAML (0.00s)
=== RUN   TestParseResourceETCDService
=== RUN   TestParseResourceETCDService/all_fields
--- PASS: TestParseResourceETCDService (0.00s)
    --- PASS: TestParseResourceETCDService/all_fields (0.00s)
=== RUN   TestParseResourceKubeAPIService
=== RUN   TestParseResourceKubeAPIService/all_fields
--- PASS: TestParseResourceKubeAPIService (0.00s)
    --- PASS: TestParseResourceKubeAPIService/all_fields (0.00s)
=== RUN   TestParseResourceKubeControllerService
=== RUN   TestParseResourceKubeControllerService/all_fields
--- PASS: TestParseResourceKubeControllerService (0.00s)
    --- PASS: TestParseResourceKubeControllerService/all_fields (0.00s)
=== RUN   TestParseResourceSchedulerService
=== RUN   TestParseResourceSchedulerService/all_fields
--- PASS: TestParseResourceSchedulerService (0.00s)
    --- PASS: TestParseResourceSchedulerService/all_fields (0.00s)
=== RUN   TestParseResourceKubeletService
=== RUN   TestParseResourceKubeletService/all_fields
--- PASS: TestParseResourceKubeletService (0.00s)
    --- PASS: TestParseResourceKubeletService/all_fields (0.00s)
=== RUN   TestParseResourceKubeproxyService
=== RUN   TestParseResourceKubeproxyService/all_fields
--- PASS: TestParseResourceKubeproxyService (0.00s)
    --- PASS: TestParseResourceKubeproxyService/all_fields (0.00s)
=== RUN   TestParseResourceNetwork
=== RUN   TestParseResourceNetwork/all_fields
--- PASS: TestParseResourceNetwork (0.00s)
    --- PASS: TestParseResourceNetwork/all_fields (0.00s)
=== RUN   TestParseResourceAuthentication
=== RUN   TestParseResourceAuthentication/all_fields
--- PASS: TestParseResourceAuthentication (0.00s)
    --- PASS: TestParseResourceAuthentication/all_fields (0.00s)
=== RUN   TestParseResourceAddons
--- PASS: TestParseResourceAddons (0.00s)
=== RUN   TestParseResourceAddonsInclude
--- PASS: TestParseResourceAddonsInclude (0.00s)
=== RUN   TestParseResourceAddonJobTimeout
--- PASS: TestParseResourceAddonJobTimeout (0.00s)
=== RUN   TestParseResourceSSHKeyPath
--- PASS: TestParseResourceSSHKeyPath (0.00s)
=== RUN   TestParseResourceSSHAgentAuth
--- PASS: TestParseResourceSSHAgentAuth (0.00s)
=== RUN   TestParseResourceBastionHost
=== RUN   TestParseResourceBastionHost/all_fields
--- PASS: TestParseResourceBastionHost (0.00s)
    --- PASS: TestParseResourceBastionHost/all_fields (0.00s)
=== RUN   TestParseResourceMonitoring
=== RUN   TestParseResourceMonitoring/all_fields
--- PASS: TestParseResourceMonitoring (0.00s)
    --- PASS: TestParseResourceMonitoring/all_fields (0.00s)
=== RUN   TestParseResourceRestore
=== RUN   TestParseResourceRestore/all_fields
--- PASS: TestParseResourceRestore (0.00s)
    --- PASS: TestParseResourceRestore/all_fields (0.00s)
=== RUN   TestParseResourceRotateCertificates
=== RUN   TestParseResourceRotateCertificates/all_fields
--- PASS: TestParseResourceRotateCertificates (0.00s)
    --- PASS: TestParseResourceRotateCertificates/all_fields (0.00s)
=== RUN   TestParseResourceDNS
=== RUN   TestParseResourceDNS/all_fields
--- PASS: TestParseResourceDNS (0.00s)
    --- PASS: TestParseResourceDNS/all_fields (0.00s)
=== RUN   TestParseResourceAuthorization
=== RUN   TestParseResourceAuthorization/all_fields
--- PASS: TestParseResourceAuthorization (0.00s)
    --- PASS: TestParseResourceAuthorization/all_fields (0.00s)
=== RUN   TestParseResourceIgnoreDockerVersion
--- PASS: TestParseResourceIgnoreDockerVersion (0.00s)
=== RUN   TestParseResourceKubernetesVersion
--- PASS: TestParseResourceKubernetesVersion (0.00s)
=== RUN   TestParseResourcePrivateRegistries
=== RUN   TestParseResourcePrivateRegistries/all_fields
--- PASS: TestParseResourcePrivateRegistries (0.00s)
    --- PASS: TestParseResourcePrivateRegistries/all_fields (0.00s)
=== RUN   TestParseResourceIngress
=== RUN   TestParseResourceIngress/all_fields
--- PASS: TestParseResourceIngress (0.00s)
    --- PASS: TestParseResourceIngress/all_fields (0.00s)
=== RUN   TestParseResourceClusterName
--- PASS: TestParseResourceClusterName (0.00s)
=== RUN   TestParseResourceCloudProvider
=== RUN   TestParseResourceCloudProvider/all_fields
--- PASS: TestParseResourceCloudProvider (0.00s)
    --- PASS: TestParseResourceCloudProvider/all_fields (0.00s)
=== RUN   TestParseResourcePrefixPath
--- PASS: TestParseResourcePrefixPath (0.00s)
=== RUN   TestClusterToState
=== RUN   TestClusterToState/all_fields
--- PASS: TestClusterToState (0.00s)
    --- PASS: TestClusterToState/all_fields (0.00s)
PASS
ok  	github.com/yamamoto-febc/terraform-provider-rke/rke	695.189s
?   	github.com/yamamoto-febc/terraform-provider-rke/tools/plugin-protocol-version	[no test files]
?   	github.com/yamamoto-febc/terraform-provider-rke/tools/terraform-version	[no test files]
```

</details>