### PR TITLE
rke/scheme: mark nodes_conf field as sensitive

### DIFF
--- a/rke/schema.go
+++ b/rke/schema.go
@@ -128,6 +128,7 @@ func ClusterSchema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			MinItems:    1,
 			Optional:    true,
+			Sensitive:   true,
 			Description: "Kubernetes nodes(YAML or JSON)",
 			Elem: &schema.Schema{
 				Type:      schema.TypeString,


### PR DESCRIPTION
As it may contain sensitive information like SSH private key.

NOTE: currently there is a bug in Terraform <= 0.11.4, which ignores
Sensitive: true on fields with type List, so this PR does not solve the
issue, as it will only work once Terraform bug is fixed or schema is
changed.

See hashicorp/terraform#15115 for details.

In Terraform >= 0.12.0 this problem can be mitigated by using nodes
field with dynamic synxtax.

Refs #89

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>