### PR TITLE
rke/schema: don't leak certificates field

### DIFF
--- a/rke/schema.go
+++ b/rke/schema.go
@@ -1657,8 +1657,9 @@ func ClusterSchema() map[string]*schema.Schema {
 			Sensitive: true,
 		},
 		"certificates": {
-			Type:     schema.TypeList,
-			Computed: true,
+			Type:      schema.TypeList,
+			Computed:  true,
+			Sensitive: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"id": {


### PR DESCRIPTION
Terraform from version 0.12.0 dumps entire resource structure when plan is executed,
so all certificates ends up being printed to STDOUT, which is a security issue.

By making entire top field Sensitive: true, we can hide that.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>