### PR TITLE
Added delay_on_creation parameter

### DIFF
--- a/rke/resource_rke_cluster.go
+++ b/rke/resource_rke_cluster.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/hashicorp/go-getter/helper/url"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -43,6 +44,11 @@ func resourceRKECluster() *schema.Resource {
 }
 
 func resourceRKEClusterCreate(d *schema.ResourceData, meta interface{}) error {
+
+	if delay, ok := d.GetOk("delay_on_creation"); ok && delay.(int) > 0 {
+		time.Sleep(time.Duration(delay.(int)) * time.Second)
+	}
+
 	if err := clusterUp(d, true); err != nil {
 		return wrapErrWithRKEOutputs(err)
 	}

--- a/rke/schema.go
+++ b/rke/schema.go
@@ -119,6 +119,11 @@ func NodeSchema() map[string]*schema.Schema {
 // ClusterSchema returns schema of rke_cluster
 func ClusterSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"delay_on_creation": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntAtLeast(0),
+		},
 		"disable_port_check": {
 			Type:     schema.TypeBool,
 			Optional: true,


### PR DESCRIPTION
This PR adds `delay_on_creation` parameter to rke_cluster resource.

When creating nodes and RKE cluster with same terraform module, the nodes may not be ready at the start of RKE cluster creation. (e.g.: during waiting for boot)

Usually this case can be solved by using null_resource etc, but it can be solved more simply by using `delay_on_parameter`. 
